### PR TITLE
[Patch] Fixing eos quota retrival

### DIFF
--- a/lib/private/files/objectstore/eosparser.php
+++ b/lib/private/files/objectstore/eosparser.php
@@ -191,7 +191,7 @@ class EosParser {
 		}
 		
 		$used = intval($data['usedlogicalbytes']);
-		$total = intval($data['maxlogialbytes']);
+		$total = intval($data['maxlogicalbytes']);
 		
 		return 
 		[

--- a/lib/private/files/objectstore/eosutil.php
+++ b/lib/private/files/objectstore/eosutil.php
@@ -994,6 +994,7 @@ class EosUtil {
 	
 	public static function getUserQuota()
 	{
+		self::putEnv();
 		$userId = \OC::$server->getUserSession()->getUser()->getUID();
 		list($uid, $gid) = self::getUidAndGid($userId);
 		$eosPrefix = self::getEosPrefix();


### PR DESCRIPTION
Quota query was failing because we were not putting the eos_mgm_url
variable in place.
