### PR TITLE
[Patch] EOS Requests retry loop

### DIFF
--- a/lib/private/files/objectstore/eoscmd.php
+++ b/lib/private/files/objectstore/eoscmd.php
@@ -13,9 +13,19 @@ class EosCmd {
 		$fullCmd = 'EOS_MGM_URL='.$eosMGMURL.' '.$cmd;
 		
 		$user = \OCP\User::getUser();
-		$result = null;
-		$errcode = null;
-		exec($fullCmd, $result, $errcode);
+		// Keep requesting EOS while we get a 22 error code
+		
+		$retrivalAttempts = \OC::$server->getConfig()->getSystemValue('eos_cmd_retry_attempts', -1);
+		$counter = 0;
+		do
+		{
+			$result = null;
+			$errcode = null;
+			exec($fullCmd, $result, $errcode);
+			$counter++;
+		}
+		while($errcode === 22 && $counter !== $retrivalAttempts);
+		
 		if($errcode === 0) {
 			\OCP\Util::writeLog('EOSCMD', "luser: $user cmd:$cmd errcode:$errcode", \OCP\Util::WARN);
 		} else {


### PR DESCRIPTION
The system will now keep issuing a request to EOS until either it
returns an error code different than 22, or the attempts limit is
reached (the attempt limit is configured using the system configuration
eos_cmd_retry_attempts, a value of -1 would disable the attempts limit)
