### PR TITLE
[PATCH] Add script sources for notebooks

### DIFF
--- a/lib/private/response.php
+++ b/lib/private/response.php
@@ -244,11 +244,11 @@ class OC_Response {
 		 * @see \OCP\AppFramework\Http\Response::getHeaders
 		 */
 		$policy = 'default-src \'self\'; '
-			. 'script-src \'self\' \'unsafe-eval\' \'unsafe-inline\'; '
+			. 'script-src \'self\' cdnjs.cloudflare.com cdn.mathjax.org \'unsafe-eval\' \'unsafe-inline\'; '
 			. 'style-src \'self\' \'unsafe-inline\'; '
 			. 'frame-src *; '
 			. 'img-src * data: blob:; '
-			. 'font-src \'self\' data: blob:; '
+			. 'font-src \'self\' cdn.mathjax.org data: blob:; '
 			. 'media-src *; ' 
 			. 'connect-src *';
 		header('Content-Security-Policy:' . $policy);

--- a/lib/public/appframework/http/contentsecuritypolicy.php
+++ b/lib/public/appframework/http/contentsecuritypolicy.php
@@ -50,6 +50,8 @@ class ContentSecurityPolicy {
 	/** @var array Domains from which scripts can get loaded */
 	private $allowedScriptDomains = [
 		'\'self\'',
+		'cdnjs.cloudflare.com',
+		'cdn.mathjax.org',
 	];
 	/**
 	 * @var bool Whether inline CSS is allowed
@@ -82,6 +84,7 @@ class ContentSecurityPolicy {
 	/** @var array Domains from which fonts can be loaded */
 	private $allowedFontDomains = [
 		'\'self\'',
+		'cdn.mathjax.org',
 	];
 	/** @var array Domains from which web-workers and nested browsing content can load elements */
 	private $allowedChildSrcDomains = [];


### PR DESCRIPTION
Allow external urls:
- cdnjs.cloudflare.com
- cdn.mathjax.org

in script-src Content Security Policy directive.

In old ownCloud versions this behaviour was controlled via `custom_content_security_policy` directive,
but in newer versions they rely on a ContentPolicyManager that can be called per application.

To be checked for CERNBox 9.
