### PR TITLE
Move mountType hack to propper place

### DIFF
--- a/apps/files/js/fileactions.js
+++ b/apps/files/js/fileactions.js
@@ -402,19 +402,6 @@
 		 * @param {OCA.Files.FileActionContext} context rendering context
 		 */
 		_renderInlineAction: function(actionSpec, isDefault, context) {
-			/** CERNBOX SHARE PLUGIN PATCH */
-			// HUGO here we control which actions to show or not
-			var mountType = context.$file.attr('data-mounttype');
-			if(mountType === "shared-root" && actionSpec.name === 'Delete') { 
-				return; // HUGO hide Unshare button on Shared with me
-			}
-			if(mountType === "shared-root" && actionSpec.name === "Rename") {
-				return; // HUGO hide rename button on Shared with me
-			}
-			if(mountType === "shared" && actionSpec.name === "Versions") {
-				return; // HUGO hide versions button in files under Shared with me
-			}
-			
 			var renderFunc = actionSpec.render || _.bind(this._defaultRenderAction, this);
 			var $actionEl = renderFunc(actionSpec, isDefault, context);
 			if (!$actionEl || !$actionEl.length) {

--- a/apps/files/js/fileactionsmenu.js
+++ b/apps/files/js/fileactionsmenu.js
@@ -96,6 +96,18 @@
 			);
 
 			var items = _.filter(actions, function(actionSpec) {
+				// HACK(labkode) hide unshare and other operations based on mount point
+				var mountType = self._context.fileInfoModel.get('mountType');
+				if (mountType === "shared-root" && actionSpec.name === 'Delete') {
+					return false; // HUGO hide Unshare button on Shared with me
+				}
+				if (mountType === "shared-root" && actionSpec.name === "Rename") {
+					return false; // HUGO hide rename button on Shared with me
+				}
+				if (mountType === "shared" && actionSpec.name === "Versions") {
+					return false; // HUGO hide versions button in files under Shared with me
+				}
+
 				return (
 					actionSpec.type === OCA.Files.FileActions.TYPE_DROPDOWN &&
 					(!defaultAction || actionSpec.name !== defaultAction.name)


### PR DESCRIPTION
After migration to 8.2.2, the versions and unshare actions were
triggered inline.
After the migration, theses actins live in the menu action,
that is the reason why they were enabled