### PR TITLE
Don't throw InsufficientStorage exception if freeSpace is unlimited

### DIFF
--- a/apps/dav/lib/Connector/Sabre/QuotaPlugin.php
+++ b/apps/dav/lib/Connector/Sabre/QuotaPlugin.php
@@ -101,7 +101,7 @@ class QuotaPlugin extends \Sabre\DAV\ServerPlugin {
 				$uri = rtrim($parentUri, '/') . '/' . $info['name'];
 			}
 			$freeSpace = $this->getFreeSpace($uri);
-			if ($freeSpace !== \OCP\Files\FileInfo::SPACE_UNKNOWN && $length > $freeSpace) {
+			if ( !($freeSpace === \OCP\Files\FileInfo::SPACE_UNKNOWN || $freeSpace === \OCP\Files\FileInfo::SPACE_UNLIMITED) && $length > $freeSpace) {
 				if (isset($chunkHandler)) {
 					$chunkHandler->cleanup();
 				}


### PR DESCRIPTION
getFreeSpace from lib/private/CernBox/Storage/Eos/Storage.php returns \OCP\Files\FileInfo::SPACE_UNLIMITED and checkQuota should not throw \Sabre\DAV\Exception\InsufficientStorage, because unlimited space is enough for writing a file.