### PR TITLE
Always load from DB the eos instances mapping.

### DIFF
--- a/lib/private/files/objectstore/eosinstancemanager.php
+++ b/lib/private/files/objectstore/eosinstancemanager.php
@@ -25,6 +25,9 @@ class EosInstanceManager
 	
 	public static function getAllMappings()
 	{
+		// load always from DB as redis kv pairs are not autoexpired
+		$all = self::loadCacheFromDB();
+
 		$temp = [];
 		$all = Redis::readHashFromCacheMap(self::EOS_MAPPING_REDIS_KEY);
 		if(!$all || $all === NULL)


### PR DESCRIPTION
Unless a cronjob is set in place, the eos instances mappings
are not going to be updated as redis kv pairs do not expire