### PR TITLE
Pass background-jobs as array instead of string

### DIFF
--- a/lib/private/Installer.php
+++ b/lib/private/Installer.php
@@ -571,7 +571,9 @@ class Installer {
 		if (is_null($info)) {
 			return false;
 		}
-		\OC_App::setupBackgroundJobs($info['background-jobs']);
+		//\OC_App::setupBackgroundJobs($info['background-jobs']);
+		\OC_App::setupBackgroundJobs(array($info['background-jobs']));
+
 
 		OC_App::executeRepairSteps($app, $info['repair-steps']['install']);
 


### PR DESCRIPTION
Fixes the exception below when building cernbox image for Boxed

From cernbox.Dockerfile
RUN source /opt/rh/rh-php70/enable && cd /var/www/html/cernbox && rm -rf config/config.php && ./occ maintenance:install --admin-user "_local" --admin-pass "_local"

./occ maintenance:install --admin-user "_local" --admin-pass "_local"
ownCloud is not installed - only a limited number of commands are available
creating sqlite db
An unhandled exception has been thrown:
TypeError: Argument 1 passed to OC_App::setupBackgroundJobs() must be of the type array, string given, called in /var/www/html/cernbox/lib/private/Installer.php on line 574 and defined in /var/www/html/cernbox/lib/private/legacy/app.php:1258
Stack trace:
#0 /var/www/html/cernbox/lib/private/Installer.php(574): OC_App::setupBackgroundJobs('\n\t\t\n\t')
#1 /var/www/html/cernbox/lib/private/Installer.php(539): OC\Installer::installShippedApp('files')
#2 /var/www/html/cernbox/lib/private/Setup.php(379): OC\Installer::installShippedApps()
#3 /var/www/html/cernbox/core/Command/Maintenance/Install.php(84): OC\Setup->install(Array)
#4 /var/www/html/cernbox/3rdparty/symfony/console/Command/Command.php(259): OC\Core\Command\Maintenance\Install->execute(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#5 /var/www/html/cernbox/3rdparty/symfony/console/Application.php(844): Symfony\Component\Console\Command\Command->run(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#6 /var/www/html/cernbox/3rdparty/symfony/console/Application.php(192): Symfony\Component\Console\Application->doRunCommand(Object(OC\Core\Command\Maintenance\Install), Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#7 /var/www/html/cernbox/3rdparty/symfony/console/Application.php(123): Symfony\Component\Console\Application->doRun(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#8 /var/www/html/cernbox/lib/private/Console/Application.php(146): Symfony\Component\Console\Application->run(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#9 /var/www/html/cernbox/console.php(102): OC\Console\Application->run()
#10 /var/www/html/cernbox/occ(11): require_once('/var/www/html/c...')
#11 {main}